### PR TITLE
Fix holidays_br.go

### DIFF
--- a/holidays_br.go
+++ b/holidays_br.go
@@ -10,7 +10,7 @@ func HolidaysBR(year int) YearHolidays {
 	result.add(&YearDay{time.January, 1}, &Holiday{"Ano Novo"})
 	result.add(&YearDay{time.April, 21}, &Holiday{"Dia de Tiradentes"})
 	result.add(&YearDay{time.May, 1}, &Holiday{"Dia do Trabalho"})
-	result.add(&YearDay{time.June, 15}, &Holiday{"Corpus Christi"})
+	result.add(&YearDay{time.June, 3}, &Holiday{"Corpus Christi"})
 	result.add(&YearDay{time.September, 7}, &Holiday{"Independência do Brasil"})
 	result.add(&YearDay{time.October, 12}, &Holiday{"Nossa Senhora Aparecida"})
 	result.add(&YearDay{time.November, 2}, &Holiday{"Dia de Finados"})


### PR DESCRIPTION
The corpus christi holiday was registered wrongly. It doesn't take place on the 15th but on the 3rd of June.